### PR TITLE
Fix pyyaml build

### DIFF
--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -13,4 +13,5 @@ fi
 # Workaround for uggy PyYaml v 3.12 on pypi
 # Can be removed once PyYaml 3.13 is released
 mkdir ./yaml
+export PYTHONPATH="${PYTHONPATH}:$(readlink -e ./yaml)"
 easy_install --prefix="./yaml" git+https://github.com/yaml/pyyaml

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -12,4 +12,4 @@ fi
 
 # Workaround for uggy PyYaml v 3.12 on pypi
 # Can be removed once PyYaml 3.13 is released
-pip install git+https://github.com/yaml/pyyaml
+easy_install git+https://github.com/yaml/pyyaml

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-#    brew update
-#    brew cask uninstall --force oclint
-#    brew upgrade python
+    brew update
+    brew cask uninstall --force oclint
+    brew upgrade python
 #    brew install root
 
     # Workaround for buggy PyYaml v 3.12 on pypi
     # Can be removed once PyYaml 3.13 is released
     pip3 install git+https://github.com/yaml/pyyaml
+    pip install git+https://github.com/yaml/pyyaml
 
 elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     curl -O https://root.cern.ch/download/root_v6.12.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -9,4 +9,7 @@ elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     curl -O https://root.cern.ch/download/root_v6.12.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz
     tar xzvf root_v6.12.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz
 fi
-pip install git:https://github.com/yaml/pyyaml
+
+# Workaround for uggy PyYaml v 3.12 on pypi
+# Can be removed once PyYaml 3.13 is released
+pip install git+https://github.com/yaml/pyyaml

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -13,4 +13,4 @@ fi
 # Workaround for uggy PyYaml v 3.12 on pypi
 # Can be removed once PyYaml 3.13 is released
 mkdir ./yaml
-easy_install git+https://github.com/yaml/pyyaml --prefix="./yaml"
+easy_install --prefix="./yaml" git+https://github.com/yaml/pyyaml

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -9,3 +9,4 @@ elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     curl -O https://root.cern.ch/download/root_v6.12.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz
     tar xzvf root_v6.12.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz
 fi
+pip install git:https://github.com/yaml/pyyaml

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -4,7 +4,7 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     brew update
     brew cask uninstall --force oclint
     brew upgrade python
-#    brew install root
+    brew install root
 
     # Workaround for buggy PyYaml v 3.12 on pypi
     # Can be removed once PyYaml 3.13 is released

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -5,11 +5,9 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     brew cask uninstall --force oclint
     brew upgrade python
     brew install root
-
-
-    mkdir ./yaml
-    export PYTHONPATH="${PYTHONPATH}:$(pwd)/yaml"
-    easy_install --prefix="./yaml" git+https://github.com/yaml/pyyaml
+    
+    brew install pip
+    pip install git+https://github.com/yaml/pyyaml
 
 elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     curl -O https://root.cern.ch/download/root_v6.12.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -9,7 +9,6 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     # Workaround for buggy PyYaml v 3.12 on pypi
     # Can be removed once PyYaml 3.13 is released
     pip3 install git+https://github.com/yaml/pyyaml
-    pip install git+https://github.com/yaml/pyyaml
 
 elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     curl -O https://root.cern.ch/download/root_v6.12.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -5,13 +5,18 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     brew cask uninstall --force oclint
     brew upgrade python
     brew install root
+
+
+    mkdir ./yaml
+    export PYTHONPATH="${PYTHONPATH}:$(pwd)/yaml"
+    easy_install --prefix="./yaml" git+https://github.com/yaml/pyyaml
+
 elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     curl -O https://root.cern.ch/download/root_v6.12.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz
     tar xzvf root_v6.12.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz
+
+    # Workaround for uggy PyYaml v 3.12 on pypi
+    # Can be removed once PyYaml 3.13 is released
+    pip install git+https://github.com/yaml/pyyaml
 fi
 
-# Workaround for uggy PyYaml v 3.12 on pypi
-# Can be removed once PyYaml 3.13 is released
-mkdir ./yaml
-export PYTHONPATH="${PYTHONPATH}:$(readlink -e ./yaml)"
-easy_install --prefix="./yaml" git+https://github.com/yaml/pyyaml

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -12,4 +12,5 @@ fi
 
 # Workaround for uggy PyYaml v 3.12 on pypi
 # Can be removed once PyYaml 3.13 is released
-easy_install git+https://github.com/yaml/pyyaml
+mkdir ./yaml
+easy_install git+https://github.com/yaml/pyyaml --prefix="./yaml"

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -8,7 +8,7 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
 
     # Workaround for buggy PyYaml v 3.12 on pypi
     # Can be removed once PyYaml 3.13 is released
-    pip3 install git+https://github.com/yaml/pyyaml
+    pip3 install git+https://github.com/yaml/pyyaml@b6cbfeec35e019734263a8f4e6a3340e94fe0a4f
 
 elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     curl -O https://root.cern.ch/download/root_v6.12.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz
@@ -16,6 +16,6 @@ elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 
     # Workaround for buggy PyYaml v 3.12 on pypi
     # Can be removed once PyYaml 3.13 is released
-    pip install git+https://github.com/yaml/pyyaml
+    pip install git+https://github.com/yaml/pyyaml@b6cbfeec35e019734263a8f4e6a3340e94fe0a4f
 fi
 

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -1,19 +1,20 @@
 #!/bin/bash
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    brew update
-    brew cask uninstall --force oclint
-    brew upgrade python
-    brew install root
-    
-    brew install pip
-    pip install git+https://github.com/yaml/pyyaml
+#    brew update
+#    brew cask uninstall --force oclint
+#    brew upgrade python
+#    brew install root
+
+    # Workaround for buggy PyYaml v 3.12 on pypi
+    # Can be removed once PyYaml 3.13 is released
+    pip3 install git+https://github.com/yaml/pyyaml
 
 elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     curl -O https://root.cern.ch/download/root_v6.12.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz
     tar xzvf root_v6.12.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz
 
-    # Workaround for uggy PyYaml v 3.12 on pypi
+    # Workaround for buggy PyYaml v 3.12 on pypi
     # Can be removed once PyYaml 3.13 is released
     pip install git+https://github.com/yaml/pyyaml
 fi

--- a/hepdata_lib/__init__.py
+++ b/hepdata_lib/__init__.py
@@ -1,5 +1,4 @@
 """hepdata_lib main."""
-# pylint:disable=wrong-import-order
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -8,8 +7,8 @@ import fnmatch
 import math
 from collections import defaultdict
 import subprocess
-import numpy as np
 import yaml
+import numpy as np
 import ROOT as r
 
 

--- a/hepdata_lib/__init__.py
+++ b/hepdata_lib/__init__.py
@@ -1,4 +1,5 @@
 """hepdata_lib main."""
+# pylint:disable=wrong-import-order
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function


### PR DESCRIPTION
Works now, `pip3` was the key to success. Disabled `wrong-import-order` warning in `__init__.py`, which appeared on OSX, but not linux. I suspect it came up because yaml is now installed locally.

Regarding merge: Can just squash the commits in the merge.