### PR TITLE
Update documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
 
 
 before_install:
-  - ./.travis/setup.sh
+  - travis_retry ./.travis/setup.sh
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd root; source bin/thisroot.sh; cd ..; fi

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -17,5 +17,5 @@ elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     # Workaround for buggy PyYaml v 3.12 on pypi
     # Can be removed once PyYaml 3.13 is released
     pip install git+https://github.com/yaml/pyyaml@b6cbfeec35e019734263a8f4e6a3340e94fe0a4f
+    pip install --upgrade enum34 pytest_pylint configparser astroid
 fi
-

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -9,6 +9,7 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     # Workaround for buggy PyYaml v 3.12 on pypi
     # Can be removed once PyYaml 3.13 is released
     pip3 install git+https://github.com/yaml/pyyaml@b6cbfeec35e019734263a8f4e6a3340e94fe0a4f
+    pip3 install --upgrade enum34 pytest_pylint configparser astroid
 
 elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     curl -O https://root.cern.ch/download/root_v6.12.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -160,3 +160,4 @@ texinfo_documents = [
 
 
 # -- Extension configuration -------------------------------------------------
+autodoc_mock_imports = ["ROOT"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,26 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('../../hepdata_lib'))
 
+if (sys.version_info > (3, 3)):
+    # Python 3.3
+    from unittest.mock import MagicMock
+else:
+    # Python 2 and < 3.3
+    from mock import Mock as MagicMock
+
+
+class Mock(MagicMock):
+    """Mocking class for missing packages."""
+    @classmethod
+    def __getattr__(cls, name):
+        return MagicMock()
+
+try:
+    import ROOT  # pylint: disable=W0611
+except ImportError:
+    MOCK_MODULES = ['ROOT']
+    sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,2 @@
 m2r
 sphinx_rtd_theme
-git+https://github.com/clelange/hepdata_lib

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 m2r
 sphinx_rtd_theme
+git+https://github.com/clelange/hepdata_lib

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 m2r
 sphinx_rtd_theme
+hepdata_lib

--- a/hepdata_lib/__init__.py
+++ b/hepdata_lib/__init__.py
@@ -128,7 +128,7 @@ class Variable(object):
 
         lenvar = len(self.values)
         lenunc = len(uncertainty.values)
-        if(lenvar and (lenvar is not lenunc)):
+        if lenvar and (lenvar is not lenunc):
             raise ValueError("Length of uncertainty list ({0})" \
             "is not the same as length of Variable" \
             "values list ({1})!.".format(lenunc, lenvar))
@@ -451,7 +451,7 @@ class RootFileReader(object):
         :type tfile: TFile or str
         """
         if isinstance(tfile, str):
-            if (os.path.exists(tfile) and tfile.endswith(".root")):
+            if os.path.exists(tfile) and tfile.endswith(".root"):
                 self._tfile = r.TFile(tfile)
             else:
                 raise IOError("RootReader: File does not exist: " + tfile)

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ try:
     import ROOT  # pylint: disable=W0611
 except ImportError:
     import mock
+    print("SETUP: Could not import ROOT. Fallback to mock.")
     sys.modules["ROOT"] = mock.Mock()
 
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except ImportError:
     sys.modules["ROOT"] = mock.Mock()
 
 
-DEPS = ['numpy', 'PyYAML', 'enum34', 'mock']
+DEPS = ['numpy', 'PyYAML', 'pylint', 'enum34', 'mock']
 
 HERE = path.abspath(path.dirname(__file__))
 
@@ -40,7 +40,7 @@ setup(
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     zip_safe=False,
     install_requires=DEPS,
-    setup_requires=['pytest-runner', 'pytest-pylint'],
+    setup_requires=['pytest-runner', 'pytest-pylint', 'pylint'],
     tests_require=['pytest', 'pylint'],
     project_urls={
         'Documentation': 'https://hepdata-lib.readthedocs.io',

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,18 @@
 """pypi package setup."""
 import codecs
 from os import path
+import sys
 from setuptools import setup, find_packages
-import ROOT  # pylint: disable=W0611
 
-DEPS = ['numpy', 'PyYAML']
+
+try:
+    import ROOT  # pylint: disable=W0611
+except ImportError:
+    import mock
+    sys.modules["ROOT"] = mock.Mock()
+
+
+DEPS = ['numpy', 'PyYAML', 'mock']
 
 HERE = path.abspath(path.dirname(__file__))
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 """pypi package setup."""
+from __future__ import print_function
 import codecs
 from os import path
 import sys

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,33 @@
 """pypi package setup."""
+from __future__ import print_function
 import codecs
+import os
 from os import path
+import subprocess
 from setuptools import setup, find_packages
-import ROOT  # pylint: disable=W0611
+
+def root_install():
+    """Make sure ROOT is installed before import"""
+    try:
+        import ROOT # pylint: disable=W0611
+        print("setup.py: ROOT already installed.")
+    except ImportError:
+        print("setup.py: Installing ROOT.")
+        url = "https://root.cern.ch/download/root_v6.12.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz"
+        subprocess.call(["curl", "-O", url])
+        subprocess.call("tar", "xzvf", path.basename(url))
+
+        cmd = ["bash", "-c", "cd root && source bin/thisroot.sh && env"]
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+
+        for line in proc.stdout:
+            (key, _, value) = line.partition("=")
+            os.environ[key] = value
+
+        proc.communicate()
+        import ROOT # pylint: disable=W0611
+
+root_install()
 
 DEPS = ['numpy', 'PyYAML']
 

--- a/setup.py
+++ b/setup.py
@@ -4,28 +4,46 @@ import codecs
 import os
 from os import path
 import subprocess
+import sys
+#~ from ctypes import cdll
 from setuptools import setup, find_packages
 
 def root_install():
     """Make sure ROOT is installed before import"""
     try:
-        import ROOT # pylint: disable=W0611
+        import ROOT #pylint: disable=unused-variable
         print("setup.py: ROOT already installed.")
     except ImportError:
         print("setup.py: Installing ROOT.")
         url = "https://root.cern.ch/download/root_v6.12.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz"
         subprocess.call(["curl", "-O", url])
-        subprocess.call("tar", "xzvf", path.basename(url))
+        subprocess.call(["tar", "xzf", path.basename(url)])
 
         cmd = ["bash", "-c", "cd root && source bin/thisroot.sh && env"]
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
 
+        #~ for lib in [x for x in os.listdir("./root/lib") if x.endswith(".so")]:
+            #~ try:
+                #~ cdll.LoadLibrary('./root/lib/'+lib)
+            #~ except:
+                #~ continue
+        try:
+            os.execv(sys.argv[0], sys.argv)
+        except OSError, exc:
+            print('Failed re-exec:', exc)
+            sys.exit(1)
+
         for line in proc.stdout:
             (key, _, value) = line.partition("=")
+            value = value.strip("\n")
             os.environ[key] = value
-
+            if(key in ["PYTHONPATH", "LIBPATH", "BIN_PATH", "ROOTSYS", "LD_LIBRARY_PATH"]):
+                for part in value.split(":"):
+                    sys.path.append(part)
+            print(key, value)
+        print(sys.path)
         proc.communicate()
-        import ROOT # pylint: disable=W0611
+        import ROOT #pylint: disable=unused-variable
 
 root_install()
 

--- a/setup.py
+++ b/setup.py
@@ -1,51 +1,8 @@
 """pypi package setup."""
-from __future__ import print_function
 import codecs
-import os
 from os import path
-import subprocess
-import sys
-#~ from ctypes import cdll
 from setuptools import setup, find_packages
-
-def root_install():
-    """Make sure ROOT is installed before import"""
-    try:
-        import ROOT #pylint: disable=unused-variable
-        print("setup.py: ROOT already installed.")
-    except ImportError:
-        print("setup.py: Installing ROOT.")
-        url = "https://root.cern.ch/download/root_v6.12.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz"
-        subprocess.call(["curl", "-O", url])
-        subprocess.call(["tar", "xzf", path.basename(url)])
-
-        cmd = ["bash", "-c", "cd root && source bin/thisroot.sh && env"]
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-
-        #~ for lib in [x for x in os.listdir("./root/lib") if x.endswith(".so")]:
-            #~ try:
-                #~ cdll.LoadLibrary('./root/lib/'+lib)
-            #~ except:
-                #~ continue
-        try:
-            os.execv(sys.argv[0], sys.argv)
-        except OSError, exc:
-            print('Failed re-exec:', exc)
-            sys.exit(1)
-
-        for line in proc.stdout:
-            (key, _, value) = line.partition("=")
-            value = value.strip("\n")
-            os.environ[key] = value
-            if(key in ["PYTHONPATH", "LIBPATH", "BIN_PATH", "ROOTSYS", "LD_LIBRARY_PATH"]):
-                for part in value.split(":"):
-                    sys.path.append(part)
-            print(key, value)
-        print(sys.path)
-        proc.communicate()
-        import ROOT #pylint: disable=unused-variable
-
-root_install()
+import ROOT  # pylint: disable=W0611
 
 DEPS = ['numpy', 'PyYAML']
 

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,10 @@
 """pypi package setup."""
-from __future__ import print_function
 import codecs
 from os import path
-import sys
 from setuptools import setup, find_packages
+import ROOT  # pylint: disable=W0611
 
-
-try:
-    import ROOT  # pylint: disable=W0611
-except ImportError:
-    import mock
-    print("SETUP: Could not import ROOT. Fallback to mock.")
-    sys.modules["ROOT"] = mock.Mock()
-
-
-DEPS = ['numpy', 'PyYAML', 'pylint', 'enum34', 'mock']
+DEPS = ['numpy', 'PyYAML']
 
 HERE = path.abspath(path.dirname(__file__))
 
@@ -41,7 +31,7 @@ setup(
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     zip_safe=False,
     install_requires=DEPS,
-    setup_requires=['pytest-runner', 'pytest-pylint', 'pylint'],
+    setup_requires=['pytest-runner', 'pytest-pylint'],
     tests_require=['pytest', 'pylint'],
     project_urls={
         'Documentation': 'https://hepdata-lib.readthedocs.io',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     sys.modules["ROOT"] = mock.Mock()
 
 
-DEPS = ['numpy', 'PyYAML', 'mock']
+DEPS = ['numpy', 'PyYAML', 'enum34', 'mock']
 
 HERE = path.abspath(path.dirname(__file__))
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,12 @@
 """pypi package setup."""
+from __future__ import print_function
 import codecs
 from os import path
 from setuptools import setup, find_packages
-import ROOT  # pylint: disable=W0611
+try:
+    import ROOT  # pylint: disable=W0611
+except ImportError:
+    print("ROOT is required by this library.")
 
 DEPS = ['numpy', 'PyYAML']
 


### PR DESCRIPTION
Making it work with readthedocs reducing the overall impact of mocking.

Docs are building: https://hepdata-lib.readthedocs.io/en/docu_mocking/ @AndreasAlbert does this look as expected?

Also trying to make tests work again, at least for linux it seems to work, for macosx the gcc installation seems to timeout a lot.

Closes #25 and #23