### PR TITLE
remove pylint temporarily

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,3 @@ universal=1
 
 [aliases]
 test=pytest
-
-[tool:pytest]
-addopts = --pylint

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ setup(
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     zip_safe=False,
     install_requires=DEPS,
-    setup_requires=['pytest-runner', 'pytest-pylint'],
-    tests_require=['pytest', 'pylint'],
+    setup_requires=['pytest-runner'],
+    tests_require=['pytest'],
     project_urls={
         'Documentation': 'https://hepdata-lib.readthedocs.io',
         'Bug Reports': 'https://github.com/clelange/hepdata_lib/issues',


### PR DESCRIPTION
I'd suggest to remove pylint temporarily to make things work again, and in particular get the documentation to be built. We can add it back at a later stage.
I'll try to get back to it in the next couple of days.

Closes #32 