### PR TITLE
Reenable pylint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ install:
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then python setup.py test; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then python3 setup.py test && python3 -m pylint hepdata_lib/__init__.py; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then python3 setup.py test && python3 -m pip install -e . && python3 -m pylint hepdata_lib/__init__.py; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ install:
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then python setup.py test; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then python3 setup.py test; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then python3 setup.py test && pylint hepdata_lib/__init__.py; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ install:
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then python setup.py test; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then python3 setup.py test && pylint hepdata_lib/__init__.py; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then python3 setup.py test && python3 -m pylint hepdata_lib/__init__.py; fi

--- a/hepdata_lib/__init__.py
+++ b/hepdata_lib/__init__.py
@@ -92,9 +92,11 @@ def check_file_size(path_to_file, upper_limit=None, lower_limit=None):
     """
     size = 1e-6 * os.path.getsize(path_to_file)
     if upper_limit and size > upper_limit:
-        raise RuntimeError("File too big: '{0}'. Maximum allowed value is {1} MB.".format(path_to_file, upper_limit))
+        raise RuntimeError("File too big: '{0}'. Maximum allowed value is {1} \
+                            MB.".format(path_to_file, upper_limit))
     if lower_limit and size < lower_limit:
-        raise RuntimeError("File too small: '{0}'. Minimal allowed value is {1} MB.".format(path_to_file, lower_limit))
+        raise RuntimeError("File too small: '{0}'. Minimal allowed value is {1} \
+                            MB.".format(path_to_file, lower_limit))
 
 class Variable(object):
     """A Variable is a wrapper for a list of values + some meta data."""
@@ -432,8 +434,9 @@ class Submission(object):
         into the output directory. This only works if the location is a local file.
         If the location you gave does not exist or points to a file larger than 100 MB,
         a RuntimeError will be raised.
-        While the file checks are performed immediately (i.e. the file must exist when this function is called),
-        the actual copying only happens once create_files function of the submission object is called.
+        While the file checks are performed immediately (i.e. the file must exist when this
+        function is called), the actual copying only happens once create_files function of the
+        submission object is called.
 
         :param description: Description of what the resource is.
         :type description: string.
@@ -447,7 +450,7 @@ class Submission(object):
 
         resource = {}
         resource["description"] = description
-        if(copy_file):
+        if copy_file:
             check_file_existence(location)
             check_file_size(location, upper_limit=100)
             resource["location"] = os.path.basename(location)
@@ -839,7 +842,7 @@ def get_hist_2d_points(hist):
             if symmetric:
                 dz_val = hist.GetBinError(x_bin, y_bin)
             else:
-                dz_val = (- hist.GetBinErrorLow(x_bin, y_bin), 
+                dz_val = (- hist.GetBinErrorLow(x_bin, y_bin),
                           hist.GetBinErrorUp(x_bin, y_bin))
 
             width_y = hist.GetXaxis().GetBinWidth(y_bin)

--- a/pylintrc
+++ b/pylintrc
@@ -282,7 +282,7 @@ init-import=no
 
 # List of qualified module names which can have objects that can redefine
 # builtins.
-redefining-builtins-modules=six.moves,past.builtins,future.builtins
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins
 
 
 [FORMAT]

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,6 @@ universal=1
 
 [aliases]
 test=pytest
+
+[tool:pytest]
+addopts = --pylint

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,4 +9,3 @@ universal=1
 test=pytest
 
 [tool:pytest]
-addopts = --pylint

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,8 @@ setup(
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     zip_safe=False,
     install_requires=DEPS,
-    setup_requires=['pytest-runner'],
-    tests_require=['pytest'],
+    setup_requires=['pytest-runner', 'pytest-pylint'],
+    tests_require=['pytest', 'pylint'],
     project_urls={
         'Documentation': 'https://hepdata-lib.readthedocs.io',
         'Bug Reports': 'https://github.com/clelange/hepdata_lib/issues',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     print("ROOT is required by this library.")
 
-DEPS = ['numpy', 'PyYAML', 'future', 'pylint', 'enum34']
+DEPS = ['numpy', 'PyYAML', 'future', 'pylint']
 
 HERE = path.abspath(path.dirname(__file__))
 
@@ -35,8 +35,8 @@ setup(
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     zip_safe=False,
     install_requires=DEPS,
-    setup_requires=['pytest-runner', 'pytest-pylint'],
-    tests_require=['pytest', 'pylint'],
+    setup_requires=['pytest-runner'],
+    tests_require=['pytest'],
     project_urls={
         'Documentation': 'https://hepdata-lib.readthedocs.io',
         'Bug Reports': 'https://github.com/clelange/hepdata_lib/issues',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     print("ROOT is required by this library.")
 
-DEPS = ['numpy', 'PyYAML', 'future']
+DEPS = ['numpy', 'PyYAML', 'future', 'pylint', 'enum34']
 
 HERE = path.abspath(path.dirname(__file__))
 

--- a/tests/test_rootfilereader.py
+++ b/tests/test_rootfilereader.py
@@ -263,7 +263,7 @@ class TestRootFileReader(TestCase):
         NY = 17
         Nfill = 1000
 
-        hist = ROOT.TH2D("test2_asym", "test2d_asym", NX, 0, 1, NY, 0, 1)
+        hist = ROOT.TH2D("test2d_asym", "test2d_asym", NX, 0, 1, NY, 0, 1)
         hist.SetBinErrorOption(ROOT.TH1.kPoisson)
         for val in np.random.normal(loc=0.5, scale=0.15, size=(Nfill, 2)):
             hist.Fill(*val)

--- a/tests/test_rootfilereader.py
+++ b/tests/test_rootfilereader.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 """Test RootFileReader."""
-import random
 from unittest import TestCase
+import os
+import ctypes
 from test_utilities import float_compare, tuple_compare
 from hepdata_lib import RootFileReader
 import numpy as np
 import ROOT
-import os
-import array
-import ctypes
+
 
 class TestRootFileReader(TestCase):
     """Test the RootFileReader class."""
@@ -23,15 +22,15 @@ class TestRootFileReader(TestCase):
         filepath = "testfile.root"
         name = "testgraph"
 
-        x = np.random.uniform(-1e3,1e3,N)
-        y = np.random.uniform(-1e3,1e3,N)
+        x = np.random.uniform(-1e3, 1e3, N)
+        y = np.random.uniform(-1e3, 1e3, N)
 
         # Create a graph and write to file
         g = ROOT.TGraph()
-        for i, (ix,iy) in enumerate(zip(x,y)):
-            g.SetPoint(i,ix,iy)
+        for i, (ix, iy) in enumerate(zip(x, y)):
+            g.SetPoint(i, ix, iy)
 
-        f = ROOT.TFile(filepath,"RECREATE")
+        f = ROOT.TFile(filepath, "RECREATE")
         f.cd()
         g.Write(name)
         f.Close()
@@ -40,14 +39,14 @@ class TestRootFileReader(TestCase):
         reader = RootFileReader(filepath)
         data = reader.read_graph(name)
 
-        self.assertTrue(set(data.keys()) == set(["x","y"]))
+        self.assertTrue(set(data.keys()) == set(["x", "y"]))
         self.assertTrue(all(data["x"] == x))
         self.assertTrue(all(data["y"] == y))
 
         # Clean up
         os.remove(filepath)
 
-    def test_read_graph_tgrapherros(self):
+    def test_read_graph_tgrapherrors(self):
         """
         Test the behavior of the read_graph function
         when reading a TGraphErrors from file.
@@ -56,17 +55,17 @@ class TestRootFileReader(TestCase):
         filepath = "testfile.root"
         name = "testgraph"
 
-        x = np.random.uniform(-1e3,1e3,N)
-        dx = np.random.uniform(-1e3,1e3,N)
-        y = np.random.uniform(-1e3,1e3,N)
-        dy = np.random.uniform(-1e3,1e3,N)
+        x = np.random.uniform(-1e3, 1e3, N)
+        dx = np.random.uniform(-1e3, 1e3, N)
+        y = np.random.uniform(-1e3, 1e3, N)
+        dy = np.random.uniform(-1e3, 1e3, N)
 
         # Create a graph and write to file
         g = ROOT.TGraphErrors()
-        for i, (ix,iy,idx,idy) in enumerate(zip(x,y,dx,dy)):
-            g.SetPoint(i,ix,iy)
-            g.SetPointError(i,idx,idy)
-        f = ROOT.TFile(filepath,"RECREATE")
+        for i, (ix, iy, idx, idy) in enumerate(zip(x, y, dx, dy)):
+            g.SetPoint(i, ix, iy)
+            g.SetPointError(i, idx, idy)
+        f = ROOT.TFile(filepath, "RECREATE")
         f.cd()
         g.Write(name)
         f.Close()
@@ -75,7 +74,7 @@ class TestRootFileReader(TestCase):
         reader = RootFileReader(filepath)
         data = reader.read_graph(name)
 
-        self.assertTrue(set(data.keys()) == set(["x","y","dx","dy"]))
+        self.assertTrue(set(data.keys()) == set(["x", "y", "dx", "dy"]))
         self.assertTrue(all(data["x"] == x))
         self.assertTrue(all(data["y"] == y))
         self.assertTrue(all(data["dx"] == dx))
@@ -84,7 +83,7 @@ class TestRootFileReader(TestCase):
         # Clean up
         os.remove(filepath)
 
-    def test_read_graph_tgrapherros(self):
+    def test_read_graph_tgrapherrors2(self):
         """
         Test the behavior of the read_graph function
         when reading a TGraphAsymmErrors from file.
@@ -93,19 +92,19 @@ class TestRootFileReader(TestCase):
         filepath = "testfile.root"
         name = "testgraph"
 
-        x = np.random.uniform(-1e3,1e3,N)
-        dx1 = np.random.uniform(0,1e3,N)
-        dx2 = np.random.uniform(0,1e3,N)
-        y = np.random.uniform(-1e3,1e3,N)
-        dy1 = np.random.uniform(0,1e3,N)
-        dy2 = np.random.uniform(0,1e3,N)
+        x = np.random.uniform(-1e3, 1e3, N)
+        dx1 = np.random.uniform(0, 1e3, N)
+        dx2 = np.random.uniform(0, 1e3, N)
+        y = np.random.uniform(-1e3, 1e3, N)
+        dy1 = np.random.uniform(0, 1e3, N)
+        dy2 = np.random.uniform(0, 1e3, N)
 
         # Create a graph and write to file
         g = ROOT.TGraphAsymmErrors()
-        for i, (ix,iy,idx1,idx2,idy1,idy2) in enumerate(zip(x,y,dx1,dx2,dy1,dy2)):
-            g.SetPoint(i,ix,iy)
-            g.SetPointError(i,idx1,idx2,idy1,idy2)
-        f = ROOT.TFile(filepath,"RECREATE")
+        for i, (ix, iy, idx1, idx2, idy1, idy2) in enumerate(zip(x, y, dx1, dx2, dy1, dy2)):
+            g.SetPoint(i, ix, iy)
+            g.SetPointError(i, idx1, idx2, idy1, idy2)
+        f = ROOT.TFile(filepath, "RECREATE")
         f.cd()
         g.Write(name)
         f.Close()
@@ -114,13 +113,13 @@ class TestRootFileReader(TestCase):
         reader = RootFileReader(filepath)
         data = reader.read_graph(name)
 
-        self.assertTrue(set(data.keys()) == set(["x","y","dx","dy"]))
+        self.assertTrue(set(data.keys()) == set(["x", "y", "dx", "dy"]))
         self.assertTrue(all(data["x"] == x))
         self.assertTrue(all(data["y"] == y))
 
         # Downward error has a minus sign -> flip
-        self.assertTrue(data["dx"] == list(zip([-tmp for tmp in dx1],dx2)))
-        self.assertTrue(data["dy"] == list(zip([-tmp for tmp in dy1],dy2)))
+        self.assertTrue(data["dx"] == list(zip([-tmp for tmp in dx1], dx2)))
+        self.assertTrue(data["dy"] == list(zip([-tmp for tmp in dy1], dy2)))
 
         # Clean up
         os.remove(filepath)
@@ -132,15 +131,15 @@ class TestRootFileReader(TestCase):
         # Create test histogram
         N = 100
         x_values = [0.5 + x for x in range(N)]
-        y_values = list(np.random.uniform(-1e3,1e3,N))
-        dy_values = list(np.random.uniform(0,1e3,N))
+        y_values = list(np.random.uniform(-1e3, 1e3, N))
+        dy_values = list(np.random.uniform(0, 1e3, N))
 
-        hist = ROOT.TH1D("test1d_symm","test1d_symm",N,0,N)
-        for i in range(1,hist.GetNbinsX()+1):
-            hist.SetBinContent(i,y_values[i-1])
-            hist.SetBinError(i,dy_values[i-1])
+        hist = ROOT.TH1D("test1d_symm", "test1d_symm", N, 0, N)
+        for i in range(1, hist.GetNbinsX()+1):
+            hist.SetBinContent(i, y_values[i-1])
+            hist.SetBinError(i, dy_values[i-1])
 
-        f = ROOT.TFile(fpath,"RECREATE")
+        f = ROOT.TFile(fpath, "RECREATE")
         hist.SetDirectory(f)
         hist.Write("test")
         f.Close()
@@ -164,11 +163,11 @@ class TestRootFileReader(TestCase):
 
         # Create test histogram
         Nbin = 17
-        Nfill = 1000        
-        hist = ROOT.TH1D("test1d_asymm","test1d_asymm",Nbin,0,1)
+        Nfill = 1000
+        hist = ROOT.TH1D("test1d_asymm", "test1d_asymm", Nbin, 0, 1)
         hist.SetBinErrorOption(ROOT.TH1.kPoisson)
 
-        for val in np.random.normal(loc=0.5,scale=0.15,size=Nfill):
+        for val in np.random.normal(loc=0.5, scale=0.15, size=Nfill):
             hist.Fill(val)
 
         # Extract values
@@ -181,7 +180,7 @@ class TestRootFileReader(TestCase):
             dy_values.append((-hist.GetBinErrorLow(i), hist.GetBinErrorUp(i)))
 
         # Write to file
-        f = ROOT.TFile(fpath,"RECREATE")
+        f = ROOT.TFile(fpath, "RECREATE")
         hist.SetDirectory(f)
         hist.Write("test")
         f.Close()
@@ -200,6 +199,7 @@ class TestRootFileReader(TestCase):
         # Clean up
         os.remove(fpath)
 
+
     def test_read_hist_2d_symmetric_errors(self):
         """Test the read_hist_2d function with symmetric errors."""
         fpath = "testfile.root"
@@ -212,16 +212,16 @@ class TestRootFileReader(TestCase):
         z_values = np.random.uniform(-1e3, 1e3, (NX, NY))
         dz_values = np.random.uniform(0, 1e3, (NX, NY))
 
-        hist = ROOT.TH2D("test2d", "test2d", NX, 0 ,NX, NY, 0, NY)
+        hist = ROOT.TH2D("test2d", "test2d", NX, 0, NX, NY, 0, NY)
 
-        for ix in range(1,hist.GetNbinsX()+1):
-            for iy in range(1,hist.GetNbinsY()+1):
-                ibin = hist.GetBin(ix,iy)
-                hist.SetBinContent(ibin,z_values[ix-1][iy-1])
-                hist.SetBinError(ibin,dz_values[ix-1][iy-1])
+        for ix in range(1, hist.GetNbinsX()+1):
+            for iy in range(1, hist.GetNbinsY()+1):
+                ibin = hist.GetBin(ix, iy)
+                hist.SetBinContent(ibin, z_values[ix-1][iy-1])
+                hist.SetBinError(ibin, dz_values[ix-1][iy-1])
 
         backup_hist = hist.Clone("backup")
-        f = ROOT.TFile(fpath,"RECREATE")
+        f = ROOT.TFile(fpath, "RECREATE")
         hist.SetDirectory(f)
         hist.Write("test")
         f.Close()
@@ -234,7 +234,7 @@ class TestRootFileReader(TestCase):
 
         # Check length
         for v in points.values():
-            self.assertTrue(len(v)==NX*NY)
+            self.assertTrue(len(v) == NX*NY)
 
         # Check unordered contents
         self.assertTrue(set(points["x"]) == set(x_values))
@@ -263,18 +263,13 @@ class TestRootFileReader(TestCase):
         NY = 17
         Nfill = 1000
 
-        hist = ROOT.TH2D("test2d", "test2d", NX, 0 , 1, NY, 0, 1)
+        hist = ROOT.TH2D("test2d", "test2d", NX, 0, 1, NY, 0, 1)
         hist.SetBinErrorOption(ROOT.TH1.kPoisson)
-        for val in np.random.normal(loc = 0.5, scale = 0.15, size = (Nfill, 2)):
+        for val in np.random.normal(loc=0.5, scale=0.15, size=(Nfill, 2)):
             hist.Fill(*val)
 
-        x_values = []
-        y_values = []
-        z_values = []
-
-
         backup_hist = hist.Clone("backup")
-        
+
         # Write to file
         f = ROOT.TFile(fpath, "RECREATE")
         hist.SetDirectory(f)
@@ -303,7 +298,7 @@ class TestRootFileReader(TestCase):
             self.assertTrue(float_compare(backup_hist.GetYaxis().GetBinCenter(ibiny.value), y))
             self.assertTrue(float_compare(backup_hist.GetBinContent(ibin), z))
             self.assertTrue(tuple_compare(
-                            (-backup_hist.GetBinErrorLow(ibinx.value, ibiny.value), 
-                            backup_hist.GetBinErrorUp(ibinx.value, ibiny.value)), dz))
+                (-backup_hist.GetBinErrorLow(ibinx.value, ibiny.value),
+                 backup_hist.GetBinErrorUp(ibinx.value, ibiny.value)), dz))
         # Clean up
         os.remove(fpath)

--- a/tests/test_rootfilereader.py
+++ b/tests/test_rootfilereader.py
@@ -221,12 +221,13 @@ class TestRootFileReader(TestCase):
                 hist.SetBinError(ibin, dz_values[ix-1][iy-1])
 
         backup_hist = hist.Clone("backup")
-        f = ROOT.TFile(fpath, "RECREATE")
-        hist.SetDirectory(f)
-        hist.Write("test")
+        rfile = ROOT.TFile(fpath, "RECREATE")
+        hist.SetDirectory(rfile)
+        hist.Write("test2d_sym")
+        rfile.Close()
 
         reader = RootFileReader(fpath)
-        points = reader.read_hist_2d("test")
+        points = reader.read_hist_2d("test2d_sym")
 
         # Check keys
         self.assertTrue(set(["x", "y", "z", "x_edges", "y_edges", "dz"]) == set(points.keys()))
@@ -251,7 +252,6 @@ class TestRootFileReader(TestCase):
             self.assertTrue(float_compare(backup_hist.GetBinContent(ibin), z))
             self.assertTrue(float_compare(backup_hist.GetBinError(ibin), dz))
         # Clean up
-        f.Close()
         os.remove(fpath)
 
     def test_read_hist_2d_asymmetric_errors(self):
@@ -263,7 +263,7 @@ class TestRootFileReader(TestCase):
         NY = 17
         Nfill = 1000
 
-        hist = ROOT.TH2D("test2d", "test2d", NX, 0, 1, NY, 0, 1)
+        hist = ROOT.TH2D("test2_asym", "test2d_asym", NX, 0, 1, NY, 0, 1)
         hist.SetBinErrorOption(ROOT.TH1.kPoisson)
         for val in np.random.normal(loc=0.5, scale=0.15, size=(Nfill, 2)):
             hist.Fill(*val)
@@ -271,13 +271,14 @@ class TestRootFileReader(TestCase):
         backup_hist = hist.Clone("backup")
 
         # Write to file
-        f = ROOT.TFile(fpath, "RECREATE")
-        hist.SetDirectory(f)
-        hist.Write("test")
+        rfile = ROOT.TFile(fpath, "RECREATE")
+        hist.SetDirectory(rfile)
+        hist.Write("test2d_asym")
+        rfile.Close()
 
         # Read back
         reader = RootFileReader(fpath)
-        points = reader.read_hist_2d("test")
+        points = reader.read_hist_2d("test2d_asym")
 
         # Check keys
         self.assertTrue(set(["x", "y", "z", "x_edges", "y_edges", "dz"]) == set(points.keys()))
@@ -300,5 +301,4 @@ class TestRootFileReader(TestCase):
                 (-backup_hist.GetBinErrorLow(ibinx.value, ibiny.value),
                  backup_hist.GetBinErrorUp(ibinx.value, ibiny.value)), dz))
         # Clean up
-        f.Close()
         os.remove(fpath)

--- a/tests/test_rootfilereader.py
+++ b/tests/test_rootfilereader.py
@@ -212,7 +212,7 @@ class TestRootFileReader(TestCase):
         z_values = np.random.uniform(-1e3, 1e3, (NX, NY))
         dz_values = np.random.uniform(0, 1e3, (NX, NY))
 
-        hist = ROOT.TH2D("test2d", "test2d", NX, 0, NX, NY, 0, NY)
+        hist = ROOT.TH2D("test2d_sym", "test2d_sym", NX, 0, NX, NY, 0, NY)
 
         for ix in range(1, hist.GetNbinsX()+1):
             for iy in range(1, hist.GetNbinsY()+1):
@@ -224,7 +224,6 @@ class TestRootFileReader(TestCase):
         f = ROOT.TFile(fpath, "RECREATE")
         hist.SetDirectory(f)
         hist.Write("test")
-        f.Close()
 
         reader = RootFileReader(fpath)
         points = reader.read_hist_2d("test")
@@ -252,6 +251,7 @@ class TestRootFileReader(TestCase):
             self.assertTrue(float_compare(backup_hist.GetBinContent(ibin), z))
             self.assertTrue(float_compare(backup_hist.GetBinError(ibin), dz))
         # Clean up
+        f.Close()
         os.remove(fpath)
 
     def test_read_hist_2d_asymmetric_errors(self):
@@ -274,7 +274,6 @@ class TestRootFileReader(TestCase):
         f = ROOT.TFile(fpath, "RECREATE")
         hist.SetDirectory(f)
         hist.Write("test")
-        f.Close()
 
         # Read back
         reader = RootFileReader(fpath)
@@ -301,4 +300,5 @@ class TestRootFileReader(TestCase):
                 (-backup_hist.GetBinErrorLow(ibinx.value, ibiny.value),
                  backup_hist.GetBinErrorUp(ibinx.value, ibiny.value)), dz))
         # Clean up
+        f.Close()
         os.remove(fpath)

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -32,7 +32,7 @@ class TestSubmission(TestCase):
         with self.assertRaises(TypeError):
             test_submission.add_table(test_uncertainty)
 
-    def test_add_additional_resource_input_checks(self):
+    def test_additional_resource_size(self):
         """Test the file checks in the add_additional_variable function."""
 
         testpath = "./testfile.dat"
@@ -44,8 +44,8 @@ class TestSubmission(TestCase):
 
         # Check with file that is too big
         size = int(2e8) # bytes in 200 MB
-        with open(testpath, "wb") as f:
-            f.write(bytes("\0" * size,"utf-8"))
+        with open(testpath, "wb") as testfile:
+            testfile.write(bytes("\0" * size, "utf-8"))
         with self.assertRaises(RuntimeError):
             test_submission.add_additional_resource("Some description", testpath, copy_file=True)
 
@@ -54,8 +54,8 @@ class TestSubmission(TestCase):
 
         # Check with file that is not too big.
         size = int(5e7) # bytes in 50 MB
-        with open(testpath, "wb") as f:
-            f.write(bytes("\0" * size,"utf-8"))
+        with open(testpath, "wb") as testfile:
+            testfile.write(bytes("\0" * size, "utf-8"))
         try:
             test_submission.add_additional_resource("Some description", testpath, copy_file=True)
         except RuntimeError:


### PR DESCRIPTION
- fix all pylint errors and warnings that were introduced in the meantime

With a clean environment, I managed to get the tests to run on lxplus as well (using `CMSSW_8_0_20` and a virtualenv).

@AndreasAlbert Can you please also try on lxplus and your setup?

Closes #43 