### PR TITLE
install imagemagick in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update -qq \
         python-dev \
         python-numpy \
         python-pip \
+        imagemagick \
     && localedef -i en_US -f UTF-8 en_US.UTF-8 \
     && rm -rf /packages /var/lib/apt/lists/* \
     && pip install --no-cache-dir \


### PR DESCRIPTION
Otherwise binder fails to create the thumbnails etc. since `convert` doesn't exist.

Test with:
https://mybinder.org/v2/gh/clelange/hepdata_lib/docker_imagemagick?filepath=examples/combine_limits.ipynb