### PR TITLE
Remove pyyaml workaround.

### DIFF
--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -17,17 +17,11 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     mkdir -p /usr/local/Cellar/root
     mv 6.14.02 /usr/local/Cellar/root/
 
-    # Workaround for buggy PyYaml v 3.12 on pypi
-    # Can be removed once PyYaml 3.13 is released
-    pip3 install git+https://github.com/yaml/pyyaml@b6cbfeec35e019734263a8f4e6a3340e94fe0a4f
     pip3 install --upgrade enum34 pytest_pylint configparser astroid coveralls
 
 elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     curl -O https://root.cern.ch/download/root_v6.12.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz
     tar xzvf root_v6.12.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz
 
-    # Workaround for buggy PyYaml v 3.12 on pypi
-    # Can be removed once PyYaml 3.13 is released
-    pip install git+https://github.com/yaml/pyyaml@b6cbfeec35e019734263a8f4e6a3340e94fe0a4f
     pip install --upgrade enum34 pytest_pylint configparser astroid coveralls
 fi

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -82,7 +82,7 @@ Setup on lxplus with CMSSW
 --------------------------
 
 In order to have all relevant libraries available, a straightforward alternative to using your own machine may be lxplus.
-You can use the same instructions as above, but in order to succeed, make sure to use a `CMSSW_10_2_3` environment and propagate the correct python environment to your virtual environment (other CMSSW releases may also work, but this one has been tested). In short:
+You can use the same instructions as above, but in order to succeed, make sure to use a CMSSW_10_2_3 environment and propagate the correct python environment to your virtual environment (other CMSSW releases may also work, but this one has been tested). In short:
 
 ::
 

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -76,3 +76,21 @@ You can always activate the virtual environment in another shell by calling the 
 
     workon hepdata_git
     python myscript.py # Execute script using development branch
+
+
+Setup on lxplus with CMSSW
+--------------------------
+
+In order to have all relevant libraries available, a straightforward alternative to using your own machine may be lxplus.
+You can use the same instructions as above, but in order to succeed, make sure to use a `CMSSW_10_2_3` environment and propagate the correct python environment to your virtual environment (other CMSSW releases may also work, but this one has been tested). In short:
+
+::
+
+    scramv1 project CMSSW CMSSW_10_2_3
+    cd CMSSW_10_2_3/src;
+    cmsenv
+    cd -;
+
+    mkvirtualenv -p $(which python) NameOfVirtualEnvironment
+
+    python -m pip install hepdata_lib

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     print("ROOT is required by this library.")
 
-DEPS = ['numpy', 'PyYAML>4', 'future', 'pylint']
+DEPS = ['numpy', 'PyYAML>4.*', 'future', 'pylint']
 
 HERE = path.abspath(path.dirname(__file__))
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     print("ROOT is required by this library.")
 
-DEPS = ['numpy', 'PyYAML', 'future', 'pylint']
+DEPS = ['numpy', 'PyYAML>4', 'future', 'pylint']
 
 HERE = path.abspath(path.dirname(__file__))
 


### PR DESCRIPTION
Require pyyaml version > 4 to avoid the issue described in #18 and remove the travis workaround.

Closes #18 