### PR TITLE
Fix docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update -qq \
     && localedef -i en_US -f UTF-8 en_US.UTF-8 \
     && rm -rf /packages /var/lib/apt/lists/* \
     && pip install --no-cache-dir \
+        pylint==1.9.* \
         jupyter \
         metakernel \
         zmq \


### PR DESCRIPTION
constrain `pylint` to v.1.9.* since this is the last python2 release

Tested locally, should be merged before #58 etc. so that we get a working docker image and binder examples.

Closes #60 