### PR TITLE
Fix MacOS ROOT python3 installation for TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd root; source bin/thisroot.sh; cd ..; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd 6.14.02/ && export PATH=${PATH}:${PWD}/bin && source bin/thisroot.sh && export PYTHONPATH=${PYTHONPATH}:${PWD}/lib && cd ../; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd 6.14.02/ && export PATH=${PWD}/bin:${PATH} && source bin/thisroot.sh && export PYTHONPATH=${PWD}/lib:${PYTHONPATH} && echo ${PYTHONPATH} && cd ../; fi
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then python setup.py test; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd root; source bin/thisroot.sh; cd ..; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then . ${PWD}/6.14.02/bin/thisroot.sh; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd 6.14.02/ && export PATH=${PATH}:${PWD}/bin && source bin/thisroot.sh && cd ../; fi
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then python setup.py test; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd root; source bin/thisroot.sh; cd ..; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd 6.14.02/ && export PATH=${PATH}:${PWD}/bin && source bin/thisroot.sh && cd ../; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd 6.14.02/ && export PATH=${PATH}:${PWD}/bin && source bin/thisroot.sh && export PYTHONPATH=${PYTHONPATH}:${PWD}/lib && cd ../; fi
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then python setup.py test; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd root; source bin/thisroot.sh; cd ..; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd 6.14.02/ && export PATH=${PWD}/bin:${PATH} && source bin/thisroot.sh && export PYTHONPATH=${PWD}/lib:${PYTHONPATH} && echo ${PYTHONPATH} && cd ../; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd 6.14.02/ && export PATH=${PWD}/bin:${PATH} && export PYTHONPATH=${PWD}/lib/root:${PYTHONPATH} && export LD_LIBRARY_PATH=${PWD}/lib/root:${LD_LIBRARY_PATH} && echo ${PYTHONPATH} && cd ../; fi
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then python setup.py test; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd root; source bin/thisroot.sh; cd ..; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then . /usr/local/bin/thisroot.sh; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then . ${PWD}/6.14.02/bin/thisroot.sh; fi
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then python setup.py test; fi
@@ -21,4 +21,4 @@ script:
 
 after_success:
   - coveralls
-  
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd root; source bin/thisroot.sh; cd ..; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd 6.14.02/ && export PATH=${PWD}/bin:${PATH} && export PYTHONPATH=${PWD}/lib/root:${PYTHONPATH} && export LD_LIBRARY_PATH=${PWD}/lib/root:${LD_LIBRARY_PATH} && echo ${PYTHONPATH} && cd ../; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd /usr/local/Cellar/root/6.14.02/ && export PATH=${PWD}/bin:${PATH} && export PYTHONPATH=${PWD}/lib/root:${PYTHONPATH} && export LD_LIBRARY_PATH=${PWD}/lib/root:${LD_LIBRARY_PATH} && echo ${PYTHONPATH} && cd -; fi
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then python setup.py test; fi

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -14,6 +14,8 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     # travis_wait 45 brew install root
     curl -O https://clange.web.cern.ch/clange/root-v6.14.02.tar.gz
     tar xzf root-v6.14.02.tar.gz
+    mkdir -p /usr/local/Cellar/root
+    mv 6.14.02 /usr/local/Cellar/root/
 
     # Workaround for buggy PyYaml v 3.12 on pypi
     # Can be removed once PyYaml 3.13 is released

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -8,7 +8,7 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     brew update
     brew cask uninstall --force oclint
     brew upgrade python
-    travis_wait brew install root
+    travis_wait 30 brew install root
 
     # Workaround for buggy PyYaml v 3.12 on pypi
     # Can be removed once PyYaml 3.13 is released

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -7,9 +7,9 @@ source ./.travis/travis_wait.sh
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     brew update
     brew cask uninstall --force oclint
-    brew upgrade python
+    brew upgrade python cmake libpng libtiff
     # Install ROOT dependencies
-    brew install cmake ossp-uuid davix isl libmpc gcc fftw libpng freetype fontconfig libtiff webp gd graphviz gsl lz4 tbb xrootd
+    brew install ossp-uuid davix isl libmpc gcc fftw freetype fontconfig webp gd graphviz gsl lz4 tbb xrootd
     echo "Installing ROOT"
     # travis_wait 45 brew install root
     curl -O https://clange.web.cern.ch/clange/root-v6.14.02.tar.gz

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -8,7 +8,7 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     brew update
     brew cask uninstall --force oclint
     brew upgrade python
-    travis_wait 30 brew install root
+    travis_wait 60 brew install root
 
     # Workaround for buggy PyYaml v 3.12 on pypi
     # Can be removed once PyYaml 3.13 is released

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -8,9 +8,12 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     brew update
     brew cask uninstall --force oclint
     brew upgrade python
-    brew install gcc xrootd
+    # Install ROOT dependencies
+    brew install cmake ossp-uuid davix isl libmpc gcc fftw libpng freetype fontconfig libtiff webp gd graphviz gsl lz4 tbb xrootd
     echo "Installing ROOT"
-    travis_wait 45 brew install root
+    # travis_wait 45 brew install root
+    curl -O https://clange.web.cern.ch/clange/root-v6.14.02.tar.gz
+    tar xzf root-v6.14.02.tar.gz
 
     # Workaround for buggy PyYaml v 3.12 on pypi
     # Can be removed once PyYaml 3.13 is released

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -14,6 +14,9 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     # travis_wait 45 brew install root
     curl -O https://clange.web.cern.ch/clange/root-v6.14.02.tar.gz
     tar xzf root-v6.14.02.tar.gz
+    ls
+    ls ${PWD}/6.14.02/bin/thisroot.sh
+    . ${PWD}/6.14.02/bin/thisroot.sh
 
     # Workaround for buggy PyYaml v 3.12 on pypi
     # Can be removed once PyYaml 3.13 is released

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -15,6 +15,7 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     curl -O https://clange.web.cern.ch/clange/root-v6.14.02.tar.gz
     tar xzf root-v6.14.02.tar.gz
     cd 6.14.02/
+    export PATH=${PATH}:${PWD}/bin
     source bin/thisroot.sh
     cd ../
     which root

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -14,11 +14,6 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     # travis_wait 45 brew install root
     curl -O https://clange.web.cern.ch/clange/root-v6.14.02.tar.gz
     tar xzf root-v6.14.02.tar.gz
-    cd 6.14.02/
-    export PATH=${PATH}:${PWD}/bin
-    source bin/thisroot.sh
-    cd ../
-    which root
 
     # Workaround for buggy PyYaml v 3.12 on pypi
     # Can be removed once PyYaml 3.13 is released

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
+# fail script immediately on any errors in external commands
+set -e
+
+source ./.travis/travis_wait.sh
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     brew update
     brew cask uninstall --force oclint
     brew upgrade python
-    brew install root
+    travis_wait brew install root
 
     # Workaround for buggy PyYaml v 3.12 on pypi
     # Can be removed once PyYaml 3.13 is released

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -14,9 +14,10 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     # travis_wait 45 brew install root
     curl -O https://clange.web.cern.ch/clange/root-v6.14.02.tar.gz
     tar xzf root-v6.14.02.tar.gz
-    ls
-    ls ${PWD}/6.14.02/bin/thisroot.sh
-    . ${PWD}/6.14.02/bin/thisroot.sh
+    cd 6.14.02/
+    source bin/thisroot.sh
+    cd ../
+    which root
 
     # Workaround for buggy PyYaml v 3.12 on pypi
     # Can be removed once PyYaml 3.13 is released

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -8,7 +8,9 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     brew update
     brew cask uninstall --force oclint
     brew upgrade python
-    travis_wait 60 brew install root
+    brew install gcc xrootd
+    echo "Installing ROOT"
+    travis_wait 45 brew install root
 
     # Workaround for buggy PyYaml v 3.12 on pypi
     # Can be removed once PyYaml 3.13 is released

--- a/.travis/travis_wait.sh
+++ b/.travis/travis_wait.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Taken from https://github.com/travis-ci/travis-build/blob/9edbf2a4330491dbd554b62b6a2cda25da97c7cb/lib/travis/build/templates/header.sh
+
+travis_wait() {
+  local timeout=$1
+  if [[ $timeout =~ ^[0-9]+$ ]]; then
+    # looks like an integer, so we assume it's a timeout
+    shift
+  else
+    # default value
+    timeout=20
+  fi
+  local cmd="$@"
+  local log_file=travis_wait_$$.log
+  $cmd &>$log_file &
+  local cmd_pid=$!
+  travis_jigger $! $timeout $cmd &
+  local jigger_pid=$!
+  local result
+  {
+    wait $cmd_pid 2>/dev/null
+    result=$?
+    ps -p$jigger_pid &>/dev/null && kill $jigger_pid
+  }
+  if [ $result -eq 0 ]; then
+    echo -e "\n${ANSI_GREEN}The command $cmd exited with $result.${ANSI_RESET}"
+  else
+    echo -e "\n${ANSI_RED}The command $cmd exited with $result.${ANSI_RESET}"
+  fi
+  echo -e "\n${ANSI_GREEN}Log:${ANSI_RESET}\n"
+  cat $log_file
+  return $result
+}
+
+travis_jigger() {
+  # helper method for travis_wait()
+  local cmd_pid=$1
+  shift
+  local timeout=$1 # in minutes
+  shift
+  local count=0
+  # clear the line
+  echo -e "\n"
+  while [ $count -lt $timeout ]; do
+    count=$(($count + 1))
+    echo -ne "Still running ($count of $timeout): $@\r"
+    sleep 60
+  done
+  echo -e "\n${ANSI_RED}Timeout (${timeout} minutes) reached. Terminating \"$@\"${ANSI_RESET}\n"
+  kill -9 $cmd_pid
+}


### PR DESCRIPTION
Basically I'm now just installing all ROOT dependencies first, then download a tarball of my installation from CERN and move that into the right place. Installing via homebrew takes more than the allowed 50 minutes since ROOT needs to be compiled from source...

The `travis_wait` stuff is nice to have (see https://github.com/clelange/hepdata_lib/compare/travis_wait?expand=1#diff-a677667c17d131d7fe128bf3b226afe9R14) for usage, not needed for this PR, but could be useful at a later stage for long-running tests.

Please squash-merge.