### PR TITLE
Fix docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,14 @@ RUN apt-get update -qq \
         imagemagick \
     && localedef -i en_US -f UTF-8 en_US.UTF-8 \
     && rm -rf /packages /var/lib/apt/lists/* \
-    && pip install --no-cache-dir \
+    && sed -i '/MVG/d' /etc/ImageMagick-6/policy.xml \
+    && sed -i '/PDF/{s/none/read|write/g}' /etc/ImageMagick-6/policy.xml \
+    && sed -i '/PDF/ a <policy domain="coder" rights="read|write" pattern="LABEL" />' /etc/ImageMagick-6/policy.xml \
+    && cat /etc/ImageMagick-6/policy.xml \
+    && python -m pip install --no-cache-dir \
         pylint==1.9.* \
+        ipython==5.7 \
+        ipykernel==4.10 \
         jupyter \
         metakernel \
         zmq \

--- a/hepdata_lib/__init__.py
+++ b/hepdata_lib/__init__.py
@@ -252,8 +252,8 @@ class Table(object):
                 print("ImageMagick does not seem to be installed \
                        or is not in the path - not adding any images.")
                 break
-            command = "convert -thumbnail 240x179 {}/{} {}/{}".format(
-                outdir, out_image_file, outdir, thumb_out_image_file)
+            command = "convert -thumbnail 240x179 {outdir}/{image} {outdir}/{thumb}".format(
+                outdir=outdir, image=out_image_file, thumb=thumb_out_image_file)
             helpers.execute_command(command)
             image = {}
             image["description"] = "Image file"

--- a/hepdata_lib/root_utils.py
+++ b/hepdata_lib/root_utils.py
@@ -109,7 +109,7 @@ class RootFileReader(object):
 
     def read_hist_2d(self, path_to_hist, **kwargs):
         # pylint: disable=anomalous-backslash-in-string
-        """Read in a TH2.
+        r"""Read in a TH2.
 
         :param path_to_hist: Absolute path in the current TFile.
         :type path_to_hist: str
@@ -144,7 +144,7 @@ class RootFileReader(object):
 
     def read_hist_1d(self, path_to_hist, **kwargs):
         # pylint: disable=anomalous-backslash-in-string
-        """Read in a TH1.
+        r"""Read in a TH1.
 
         :param path_to_hist: Absolute path in the current TFile.
         :type path_to_hist: str
@@ -233,7 +233,7 @@ class RootFileReader(object):
 
 def get_hist_2d_points(hist, **kwargs):
     # pylint: disable=anomalous-backslash-in-string,too-many-locals
-    """
+    r"""
     Get points from a TH2.
 
     :param hist: Histogram to extract points from
@@ -309,7 +309,7 @@ def get_hist_2d_points(hist, **kwargs):
 
 def get_hist_1d_points(hist, **kwargs):
     # pylint: disable=anomalous-backslash-in-string
-    """
+    r"""
     Get points from a TH1.
 
     :param hist: Histogram to extract points from


### PR DESCRIPTION
- restrict ipykernel and ipython versions to work with legacy python
- fix ImageMagick permissions as described in #67 
- some minor changes to make tests pass with recent pytest and pylint versions

Docker container tested locally and confirmed to work.

Closes #68 